### PR TITLE
make aio-defun compatible with namespace

### DIFF
--- a/aio.el
+++ b/aio.el
@@ -97,7 +97,8 @@ function result directly from the previously yielded promise."
 
 If the body signals an error, this error will be stored in the
 promise and rethrown in the promise's listeners."
-  (declare (indent defun))
+  (declare (indent defun)
+           (debug (&define sexp [&rest [keywordp sexp]] def-body)))
   (cl-assert (eq lexical-binding t))
   `(aio-resolve ,promise
                 (condition-case error
@@ -127,7 +128,8 @@ promises. When an async function is called, it immediately
 returns a promise that will resolve to the function's return
 value, or any uncaught error signal."
   (declare (indent defun)
-           (doc-string 3))
+           (doc-string 3)
+           (debug (&define sexp [&rest [keywordp sexp]] def-body)))
   (let ((args (make-symbol "args"))
         (promise (make-symbol "promise"))
         (split-body (macroexp-parse-body body)))
@@ -144,7 +146,8 @@ value, or any uncaught error signal."
 (defmacro aio-defun (name arglist &rest body)
   "Like `aio-lambda' but gives the function a name like `defun'."
   (declare (indent defun)
-           (doc-string 3))
+           (doc-string 3)
+           (debug (&define name sexp [&rest [keywordp sexp]] def-body)))
   `(defalias ',name (aio-lambda ,arglist ,@body)))
 
 (defun aio-wait-for (promise)
@@ -167,7 +170,8 @@ underlying asynchronous operation will not actually be canceled."
 Since BODY is evalued inside an asynchronous lambda, `aio-await'
 is available here. This macro evaluates to a promise for BODY's
 eventual result."
-  (declare (indent 0))
+  (declare (indent 0)
+           (debug ([&rest [keywordp sexp]] def-body)))
   `(let ((promise (funcall (aio-lambda ()
                              (aio-await (aio-sleep 0))
                              ,@body))))


### PR DESCRIPTION
Make `aio-defun` stuff works with [emacs namespace](https://github.com/Malabarba/names).
Please refer to this Malabarba/names#31 too