### PR TITLE
Improve Edebug specifications.

### DIFF
--- a/aio.el
+++ b/aio.el
@@ -100,7 +100,7 @@ function result directly from the previously yielded promise."
 If the body signals an error, this error will be stored in the
 promise and rethrown in the promise's listeners."
   (declare (indent defun)
-           (debug (&define sexp [&rest [keywordp sexp]] def-body)))
+           (debug (form body)))
   (cl-assert (eq lexical-binding t))
   `(aio-resolve ,promise
                 (condition-case error
@@ -131,7 +131,9 @@ returns a promise that will resolve to the function's return
 value, or any uncaught error signal."
   (declare (indent defun)
            (doc-string 3)
-           (debug (&define sexp [&rest [keywordp sexp]] def-body)))
+           (debug (&define lambda-list lambda-doc
+                           [&optional ("interactive" interactive)]
+                           def-body)))
   (let ((args (make-symbol "args"))
         (promise (make-symbol "promise"))
         (split-body (macroexp-parse-body body)))
@@ -149,7 +151,7 @@ value, or any uncaught error signal."
   "Like `aio-lambda' but gives the function a name like `defun'."
   (declare (indent defun)
            (doc-string 3)
-           (debug (&define name sexp [&rest [keywordp sexp]] def-body)))
+           (debug (&define name lambda-list def-body)))
   `(defalias ',name (aio-lambda ,arglist ,@body)))
 
 (defun aio-wait-for (promise)
@@ -173,7 +175,7 @@ Since BODY is evalued inside an asynchronous lambda, `aio-await'
 is available here. This macro evaluates to a promise for BODY's
 eventual result."
   (declare (indent 0)
-           (debug ([&rest [keywordp sexp]] def-body)))
+           (debug (body)))
   `(let ((promise (funcall (aio-lambda ()
                              (aio-await (aio-sleep 0))
                              ,@body))))


### PR DESCRIPTION
I’ve mostly copied them from ‘iter-defun’ and ‘lambda’.  The proposed ones look
more correct to me than the existing ones.