### PR TITLE
Change some Edebug specifications to ‘sexp’ to not evaluate them.

### DIFF
--- a/aio.el
+++ b/aio.el
@@ -133,7 +133,7 @@ value, or any uncaught error signal."
            (doc-string 3)
            (debug (&define lambda-list lambda-doc
                            [&optional ("interactive" interactive)]
-                           def-body)))
+                           &rest sexp)))
   (let ((args (make-symbol "args"))
         (promise (make-symbol "promise"))
         (split-body (macroexp-parse-body body)))
@@ -151,7 +151,7 @@ value, or any uncaught error signal."
   "Like `aio-lambda' but gives the function a name like `defun'."
   (declare (indent defun)
            (doc-string 3)
-           (debug (&define name lambda-list def-body)))
+           (debug (&define name lambda-list &rest sexp)))
   `(progn
      (defalias ',name (aio-lambda ,arglist ,@body))
      (function-put ',name 'aio-defun-p t)))
@@ -190,7 +190,7 @@ Beware: Dynamic bindings that are lexically outside
 
 Other global state such as the current buffer behaves likewise."
   (declare (indent 0)
-           (debug (body)))
+           (debug (&rest sexp)))
   `(let ((promise (funcall (aio-lambda ()
                              (aio-await (aio-sleep 0))
                              ,@body))))


### PR DESCRIPTION
Edebug doesn’t handle bodies rewritten by generator.el well,
cf. https://debbugs.gnu.org/cgi/bugreport.cgi?bug=40434.  Until that is fixed,
it’s better to avoid instrumented the bodies altogether to avoid spurious bugs.