### PR TITLE
Add to lisp-imenu-generic-expression

### DIFF
--- a/aio.el
+++ b/aio.el
@@ -465,6 +465,9 @@ This function is added to ‘help-fns-describe-function-functions’."
     (insert "  This function is asynchronous; it returns "
             "an ‘aio-promise’ object.\n")))
 
+(add-to-list 'lisp-imenu-generic-expression
+             (list nil (concat "^\\s-*(aio-defun\\s-+\\(" lisp-mode-symbol-regexp "\\)") 1))
+
 (provide 'aio)
 
 ;;; aio.el ends here


### PR DESCRIPTION
Fix #17 

Add `aio-defun` and `aio-lambda` to lsp-imenu-generic-expression so they are indexed to the same group as defuns and lambda.